### PR TITLE
feat: Grant write permissions to deployment workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
This commit adds the `contents: write` permission to the GitHub Actions workflow. This is necessary to allow the `peaceiris/actions-gh-pages` action to create and push to the `gh-pages` branch.

This resolves the "Permission denied" error that was causing the deployment to fail.