### PR TITLE
debug: Use inline style for FolderIcon to isolate styling issue

### DIFF
--- a/components/ProjectCard.tsx
+++ b/components/ProjectCard.tsx
@@ -11,7 +11,7 @@ const ProjectCard = ({ project }) => {
   return (
     <div className="group relative border border-[#00ff41]/50 bg-black/30 p-4 transition-all duration-300 hover:border-[#00ff41] hover:shadow-[0_0_20px_rgba(0,255,65,0.5)] h-full flex flex-col">
       <div className="flex justify-between items-start mb-2">
-        <FolderIcon className="w-8 h-8 text-[#00f0ff]" />
+        <FolderIcon style={{ width: '2rem', height: '2rem' }} className="text-[#00f0ff]" />
         <div className="flex items-center gap-3">
             {project.githubUrl && (
                  <a href={project.githubUrl} target="_blank" rel="noopener noreferrer" aria-label="GitHub Repository" className="text-[#ff00c1] hover:text-white transition-colors duration-300">


### PR DESCRIPTION
This commit changes the FolderIcon component to use an inline `style` prop for its width and height, rather than Tailwind CSS classes.

This is a temporary debugging measure. The goal is to determine if the persistent styling issue is caused by the CSS build/caching system or by the component rendering logic itself.