### PR TITLE
feat: Adjust layout and typography

### DIFF
--- a/components/ProjectCard.tsx
+++ b/components/ProjectCard.tsx
@@ -11,7 +11,7 @@ const ProjectCard = ({ project }) => {
   return (
     <div className="group relative border border-[#00ff41]/50 bg-black/30 p-4 transition-all duration-300 hover:border-[#00ff41] hover:shadow-[0_0_20px_rgba(0,255,65,0.5)] h-full flex flex-col">
       <div className="flex justify-between items-start mb-2">
-        <FolderIcon style={{ width: '2rem', height: '2rem' }} className="text-[#00f0ff]" />
+        <FolderIcon className="w-8 h-8 text-[#00f0ff]" />
         <div className="flex items-center gap-3">
             {project.githubUrl && (
                  <a href={project.githubUrl} target="_blank" rel="noopener noreferrer" aria-label="GitHub Repository" className="text-[#ff00c1] hover:text-white transition-colors duration-300">
@@ -22,7 +22,7 @@ const ProjectCard = ({ project }) => {
       </div>
        <p className="text-xs text-gray-300 mb-1">-rwxr-xr-x 1 guest guest 4096 {new Date().toLocaleDateString('en-US', { month: 'short', day: '2-digit' })}</p>
       <h3 className="text-xl font-bold text-[#00ff41] mb-2">{project.name[lang]}</h3>
-      <p className="text-gray-300 text-sm mb-4">{project.description[lang]}</p>
+      <p className="text-gray-300 text-base mb-4">{project.description[lang]}</p>
       <div className="flex flex-wrap gap-2 mt-auto pt-4">
         {project.techStack.map((tech, index) => (
           <span key={index} className="text-xs bg-[#00f0ff]/10 text-[#00f0ff] px-2 py-1">

--- a/components/ProjectList.tsx
+++ b/components/ProjectList.tsx
@@ -20,7 +20,7 @@ const ProjectList = ({ projects }) => {
             <p className="text-lg">{t.emptyProjectList}</p>
           </div>
         ) : (
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-6 w-full">
+          <div className="grid grid-cols-2 gap-6 w-full">
             {projects.map((project) => (
               <ProjectCard key={project.id} project={project} />
             ))}


### PR DESCRIPTION
This commit implements layout and text size adjustments as requested by the user.

- The project list is updated to a two-column grid (`grid-cols-2`) to display cards side-by-side on all screen sizes.
- The project description font size is increased from `text-sm` to `text-base` for better readability.
- The temporary inline style on the `FolderIcon` has been removed in favor of the permanent Tailwind CSS class-based solution, which is now working correctly.