### PR TITLE
fix: Add 404.html fallback for SPA deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,6 +25,9 @@ jobs:
       - name: Build
         run: npm run build
 
+      - name: Create 404.html for SPA fallback
+        run: cp dist/index.html dist/404.html
+
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v3
         with:


### PR DESCRIPTION
This commit adds a step to the deployment workflow to create a `404.html` file by copying the generated `index.html`.

This is a standard workaround for deploying single-page applications to GitHub Pages. It prevents errors where asset requests receive a 404 page (with a `text/html` MIME type) instead of the actual asset, which blocks the application from loading.