### PR TITLE
fix: Set Vite base to '' for relative asset paths

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,7 +5,7 @@ import react from '@vitejs/plugin-react';
 export default defineConfig(({ mode }) => {
     const env = loadEnv(mode, '.', '');
     return {
-      base: '/portfolio/',
+      base: '',
       plugins: [react()],
       define: {
         'process.env.API_KEY': JSON.stringify(env.GEMINI_API_KEY),


### PR DESCRIPTION
This commit changes the 'base' property in vite.config.ts to an empty string (''). This enables relative paths for all generated assets (e.g., './assets/file.js').

This is the definitive fix for the persistent 404 and MIME type errors when deploying to GitHub Pages, as it resolves the mismatch between the generated absolute paths and the actual file structure on the deployment server.